### PR TITLE
Fixed Numpy boolean array indexing issue for 2dim arrays.

### DIFF
--- a/mlinsights/mlmodel/piecewise_estimator.py
+++ b/mlinsights/mlmodel/piecewise_estimator.py
@@ -293,7 +293,10 @@ class PiecewiseEstimator(BaseEstimator):
         for ind, p in indpred:
             if ind is None:
                 continue
-            pred[ind] = p
+            # pred[ind] = p
+            mask = (ind==True)
+            numpy.putmask(pred,mask,p)
+
             indall = numpy.logical_or(indall, ind)  # pylint: disable=E1111
 
         # no in a bucket


### PR DESCRIPTION
Numpy requires the use of masking for all boolean array indexing on non 1 or 0-d arrays. Therefore the following line breaks all estimators when using the conventional Nx1 sklearn data format for regression, which this library also requires.

pred[ind] = p

More details: [https://stackoverflow.com/questions/60079094/python-error-numpy-boolean-array-indexing-assignment-requires-a-0-or-1-dimensi](on stack overflow)

This commit uses a mask to fix this.